### PR TITLE
DEV-2395 Add changes to METS

### DIFF
--- a/app/helpers/xml.py
+++ b/app/helpers/xml.py
@@ -140,16 +140,16 @@ def build_mh_mets(g: rdflib.Graph, pid: str) -> str:
 
     for representation in representations:
         representation_index = representation.label.split("_")[1]
-        representation_media = metsrw.FSEntry(type="Media")
-        representation_media.add_dmdsec(
-            build_minimal_sidecar(f"{pid}_{representation_index}"),
-            "OTHER",
-            **{
-                "othermdtype": "mhs:Sidecar",
-                "id": f"DMDID-MATERIALARTWORK-REPRESENTATION-{representation_index}",
-            },
-        )
         for file_index, file in enumerate(representation.files):
+            representation_media = metsrw.FSEntry(type="Media")
+            representation_media.add_dmdsec(
+                build_minimal_sidecar(f"{pid}_{representation_index}_{file_index}"),
+                "OTHER",
+                **{
+                    "othermdtype": "mhs:Sidecar",
+                    "id": f"DMDID-MATERIALARTWORK-REPRESENTATION-{representation_index}-{file_index}",
+                },
+            )
             file_representation = metsrw.FSEntry(
                 fileid=f"FILEID-MATERIALARTWORK-REPRESENTATION-{representation_index}-{file_index}",
                 use="Disk",
@@ -161,7 +161,7 @@ def build_mh_mets(g: rdflib.Graph, pid: str) -> str:
                 checksum=file.fixity,
             )
             representation_media.add_child(file_representation)
-        root_folder.add_child(representation_media)
+            root_folder.add_child(representation_media)
 
     mets.append_file(root_folder)
 

--- a/app/helpers/xml.py
+++ b/app/helpers/xml.py
@@ -141,6 +141,14 @@ def build_mh_mets(g: rdflib.Graph, pid: str) -> str:
     for representation in representations:
         representation_index = representation.label.split("_")[1]
         representation_media = metsrw.FSEntry(type="Media")
+        representation_media.add_dmdsec(
+            build_minimal_sidecar(f"{pid}_{representation_index}"),
+            "OTHER",
+            **{
+                "othermdtype": "mhs:Sidecar",
+                "id": f"DMDID-MATERIALARTWORK-REPRESENTATION-{representation_index}",
+            },
+        )
         for file_index, file in enumerate(representation.files):
             file_representation = metsrw.FSEntry(
                 fileid=f"FILEID-MATERIALARTWORK-REPRESENTATION-{representation_index}-{file_index}",
@@ -153,14 +161,6 @@ def build_mh_mets(g: rdflib.Graph, pid: str) -> str:
                 checksum=file.fixity,
             )
             representation_media.add_child(file_representation)
-            file_representation.add_dmdsec(
-                build_minimal_sidecar(f"{pid}_{representation_index}_{file_index}"),
-                "OTHER",
-                **{
-                    "othermdtype": "mhs:Sidecar",
-                    "id": f"DMDID-MATERIALARTWORK-REPRESENTATION-{representation_index}-{file_index}",
-                },
-            )
         root_folder.add_child(representation_media)
 
     mets.append_file(root_folder)
@@ -219,6 +219,15 @@ def build_mh_sidecar(
         predicate=rdflib.URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
         object=rdflib.URIRef("http://www.loc.gov/premis/rdf/v3/IntellectualEntity"),
     )
+
+    # Add external ID
+    administrative_node = etree.Element(
+        etree.QName(NSMAP["mhs"], "Administrative"), nsmap=NSMAP
+    )
+    id_node = etree.Element(etree.QName(NSMAP["mh"], "ExternalId"), nsmap=NSMAP)
+    root.append(administrative_node)
+    administrative_node.append(id_node)
+    id_node.text = pid
 
     # Add mappable fields to the XML
     for predicate in MAPPING.keys():

--- a/tests/resources/sidecar.xml
+++ b/tests/resources/sidecar.xml
@@ -1,4 +1,7 @@
 <mhs:Sidecar xmlns:mhs="https://zeticon.mediahaven.com/metadata/22.1/mhs/" xmlns:mh="https://zeticon.mediahaven.com/metadata/22.1/mh/" version="22.1">
+  <mhs:Administrative>
+    <mh:ExternalId>testpid</mh:ExternalId>
+  </mhs:Administrative>
   <mhs:Descriptive>
     <mh:Title>de titel van de episode</mh:Title>
     <mh:Description>de beschrijving van de episode</mh:Description>

--- a/tests/resources/sidecar_fit.xml
+++ b/tests/resources/sidecar_fit.xml
@@ -1,4 +1,7 @@
 <mhs:Sidecar xmlns:mhs="https://zeticon.mediahaven.com/metadata/22.1/mhs/" xmlns:mh="https://zeticon.mediahaven.com/metadata/22.1/mh/" version="22.1">
+  <mhs:Administrative>
+    <mh:ExternalId>testpid</mh:ExternalId>
+  </mhs:Administrative>
   <mhs:Descriptive>
     <mh:Title>De verheerlijking van de Heilige Maagd</mh:Title>
     <mh:Description>GIVE 2D</mh:Description>


### PR DESCRIPTION
Add changes to descriptive metadata in the METS:
- Add external ID on the top-level metadata in the MH sip.
- Move the metadata of a file to the media level in the MediahHaven SIP instead of the underlying representation level. A media record is a metadata-only record which accepts the given external ID. The fact that the underlying representation record does not accept the given external ID might be a bug though in MediaHaven, to be seen.