### PR TITLE
DEV-2403 Fix creating MH sidecar

### DIFF
--- a/app/helpers/xml.py
+++ b/app/helpers/xml.py
@@ -237,10 +237,6 @@ def build_mh_sidecar(
     administrative_node.append(id_node)
     id_node.text = pid
 
-    # Create Dynamic node
-    dynamic_tag = etree.Element(etree.QName(NSMAP["mhs"], "Dynamic"), nsmap=NSMAP)
-    root.append(dynamic_tag)
-
     # Add mappable fields to the XML
     for predicate in MAPPING.keys():
         for key in MAPPING[predicate]["targets"]:
@@ -290,6 +286,12 @@ def build_mh_sidecar(
                 xml_tag.text = obj
 
     # Add some extra dynamic metadata
+    # Create Dynamic node if needed
+    dynamic_tag = root.find("mhs:Dynamic", namespaces=NSMAP)
+    if not dynamic_tag:
+        dynamic_tag = etree.Element(etree.QName(NSMAP["mhs"], "Dynamic"), nsmap=NSMAP)
+        root.append(dynamic_tag)
+
     # Add PID
     pid_tag = etree.Element("PID")
     dynamic_tag.append(pid_tag)

--- a/app/helpers/xml.py
+++ b/app/helpers/xml.py
@@ -147,7 +147,12 @@ def build_mh_mets(g: rdflib.Graph, pid: str) -> str:
         for file_index, file in enumerate(representation.files):
             representation_media = metsrw.FSEntry(type="Media")
             representation_media.add_dmdsec(
-                build_mh_sidecar(g, representation.node, f"{pid}_{representation_index}_{file_index}", is_ie=False),
+                build_mh_sidecar(
+                    g,
+                    representation.node,
+                    f"{pid}_{representation_index}_{file_index}",
+                    is_ie=False,
+                ),
                 "OTHER",
                 **{
                     "othermdtype": "mhs:Sidecar",
@@ -208,7 +213,11 @@ def build_minimal_sidecar(external_id: str) -> str:
 
 
 def build_mh_sidecar(
-    g: rdflib.Graph, subject, pid: str, dynamic_tags: dict[str, str] = {}, is_ie: bool = True
+    g: rdflib.Graph,
+    subject,
+    pid: str,
+    dynamic_tags: dict[str, str] = {},
+    is_ie: bool = True,
 ) -> str:
     """
     Builds a MH 2.0 sidecar based on metadata from a graph
@@ -227,6 +236,10 @@ def build_mh_sidecar(
     root.append(administrative_node)
     administrative_node.append(id_node)
     id_node.text = pid
+
+    # Create Dynamic node
+    dynamic_tag = etree.Element(etree.QName(NSMAP["mhs"], "Dynamic"), nsmap=NSMAP)
+    root.append(dynamic_tag)
 
     # Add mappable fields to the XML
     for predicate in MAPPING.keys():
@@ -277,8 +290,6 @@ def build_mh_sidecar(
                 xml_tag.text = obj
 
     # Add some extra dynamic metadata
-    dynamic_tag = root.find("mhs:Dynamic", namespaces=NSMAP)
-
     # Add PID
     pid_tag = etree.Element("PID")
     dynamic_tag.append(pid_tag)
@@ -295,7 +306,9 @@ def build_mh_sidecar(
 
         # TODO
         if len(list(local_ids)) == 1:
-            main_local_id = local_ids.pop("MEEMOO-LOCAL-ID", local_ids[list(local_ids)[0]])
+            main_local_id = local_ids.pop(
+                "MEEMOO-LOCAL-ID", local_ids[list(local_ids)[0]]
+            )
         else:
             main_local_id = local_ids.pop("MEEMOO-LOCAL-ID", "")
 

--- a/tests/helpers/test_xml.py
+++ b/tests/helpers/test_xml.py
@@ -22,6 +22,13 @@ def material_artwork_ttl_graph():
 
 
 @pytest.fixture
+def material_artwork_minimal_rep_graph():
+    with open("./tests/resources/materialartwork_minimal_rep.ttl", "r") as f:
+        ttl = f.read()
+    return ttl
+
+
+@pytest.fixture
 def mh_sidecar_xml():
     with open("./tests/resources/sidecar.xml", "r") as f:
         xml = f.read()
@@ -45,6 +52,13 @@ def mets_xml():
 @pytest.fixture
 def minicar_xml():
     with open("./tests/resources/minicar.xml", "r") as f:
+        xml = f.read()
+    return xml
+
+
+@pytest.fixture
+def mh_sidecar_material_artwork_nimimal_rep_xml():
+    with open("./tests/resources/sidecar_material_artwork_minimal_rep.xml", "r") as f:
         xml = f.read()
     return xml
 
@@ -89,3 +103,18 @@ def test_build_minimal_sidecar(minicar_xml):
     minicar = build_minimal_sidecar("abcdefgh")
 
     assert minicar == minicar_xml
+
+
+def test_build_mh_sidecar_material_artwork_minimal_rep(
+    material_artwork_minimal_rep_graph, mh_sidecar_material_artwork_nimimal_rep_xml
+):
+    g = parse_graph(material_artwork_minimal_rep_graph, "ttl")
+
+    rep = g.value(
+        predicate=rdflib.URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+        object=rdflib.URIRef("http://www.loc.gov/premis/rdf/v3/Representation"),
+    )
+
+    sidecar = build_mh_sidecar(g, rep, "testpid")
+
+    assert sidecar == mh_sidecar_material_artwork_nimimal_rep_xml

--- a/tests/helpers/test_xml.py
+++ b/tests/helpers/test_xml.py
@@ -57,7 +57,7 @@ def minicar_xml():
 
 
 @pytest.fixture
-def mh_sidecar_material_artwork_nimimal_rep_xml():
+def mh_sidecar_material_artwork_minimal_rep_xml():
     with open("./tests/resources/sidecar_material_artwork_minimal_rep.xml", "r") as f:
         xml = f.read()
     return xml
@@ -106,7 +106,7 @@ def test_build_minimal_sidecar(minicar_xml):
 
 
 def test_build_mh_sidecar_material_artwork_minimal_rep(
-    material_artwork_minimal_rep_graph, mh_sidecar_material_artwork_nimimal_rep_xml
+    material_artwork_minimal_rep_graph, mh_sidecar_material_artwork_minimal_rep_xml
 ):
     g = parse_graph(material_artwork_minimal_rep_graph, "ttl")
 
@@ -117,4 +117,4 @@ def test_build_mh_sidecar_material_artwork_minimal_rep(
 
     sidecar = build_mh_sidecar(g, rep, "testpid")
 
-    assert sidecar == mh_sidecar_material_artwork_nimimal_rep_xml
+    assert sidecar == mh_sidecar_material_artwork_minimal_rep_xml

--- a/tests/resources/materialartwork_minimal_rep.ttl
+++ b/tests/resources/materialartwork_minimal_rep.ttl
@@ -1,0 +1,58 @@
+@prefix cryptographicHashFunctions: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> . 
+@prefix dct: <http://purl.org/dc/terms/> . 
+@prefix edtf: <http://id.loc.gov/datatypes/edtf/> . 
+@prefix haObj: <https://data.hetarchief.be/ns/object/> . 
+@prefix haObjId: <https://data.hetarchief.be/id/object/> . 
+@prefix haOrgId: <https://data.hetarchief.be/id/organization/> . 
+@prefix haSip: <https://data.hetarchief.be/ns/sip/> . 
+@prefix haSipId: <https://data.hetarchief.be/id/sip/1.1/> . 
+@prefix org: <http://www.w3.org/ns/org#> . 
+@prefix premisowl: <http://www.loc.gov/premis/rdf/v3/> . 
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> . 
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> . 
+@prefix relSubType: <http://id.loc.gov/vocabulary/preservation/relationshipSubType/> . 
+@prefix schema: <https://schema.org/> . 
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> . 
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+ 
+haSipId:uuid-f178c272-dbfc-4b91-810b-7b60c137d18e a haSip:SIP ; 
+    dct:conformsTo "https://data.hetarchief.be/id/sip/1.1/material-artwork", 
+        "https://earksip.dilcis.eu/profile/E-ARK-SIP.xml" ; 
+    schema:agent [ schema:agent haOrgId:OR-5h7bt1n ; 
+            schema:roleName "ARCHIVIST" ], 
+        [ schema:agent haOrgId:OR-m30wc4t ; 
+            schema:roleName "CREATOR" ] . 
+ 
+ 
+haObjId:ff7352850109a722f5c47ce67f40d181 a cryptographicHashFunctions:md5 ; 
+    rdf:value "ff7352850109a722f5c47ce67f40d181" . 
+ 
+haObjId:uuid-0be5686f-418a-4094-b7b0-1fa30e31c407 a premisowl:File ; 
+    relSubType:isi haObjId:uuid-46425b95-4c1a-4a4e-81bd-6696edb52471 ; 
+    dct:format <http://the-fr.org/id/file-format/11> ; 
+    premisowl:fixity haObjId:ff7352850109a722f5c47ce67f40d181 ; 
+    premisowl:originalName "test_image.png" ; 
+    premisowl:size 11385 . 
+ 
+ 
+haObjId:b6ef78b5cdbf259101676fcb1e676306 a cryptographicHashFunctions:md5 ; 
+    rdf:value "b6ef78b5cdbf259101676fcb1e676306" . 
+ 
+haObjId:uuid-46425b95-4c1a-4a4e-81bd-6696edb52471 a premisowl:Representation ; 
+    skos:hiddenLabel "representation_1" ; 
+    relSubType:inc haObjId:uuid-0be5686f-418a-4094-b7b0-1fa30e31c407 ; 
+    relSubType:rep haObjId:uuid-e47ea1ab-3d47-44ff-a134-a9c60a678108 . 
+
+haObjId:uuid-e47ea1ab-3d47-44ff-a134-a9c60a678108 a premisowl:IntellectualEntity ; 
+    relSubType:isr haObjId:uuid-46425b95-4c1a-4a4e-81bd-6696edb52471 ; 
+    dct:description "GIVE 2D"@nl . 
+ 
+haOrgId:OR-5h7bt1n a org:Organization ; 
+    skos:prefLabel "KMSKA"@nl ; 
+    schema:identifier "OR-5h7bt1n" . 
+ 
+haOrgId:OR-m30wc4t a org:Organization ; 
+    skos:prefLabel "artinflanders"@nl ; 
+    schema:identifier "OR-m30wc4t" . 
+ 
+<http://the-fr.org/id/file-format/11> a dct:FileFormat . 

--- a/tests/resources/sidecar_material_artwork_minimal_rep.xml
+++ b/tests/resources/sidecar_material_artwork_minimal_rep.xml
@@ -1,0 +1,10 @@
+<mhs:Sidecar xmlns:mhs="https://zeticon.mediahaven.com/metadata/22.1/mhs/" xmlns:mh="https://zeticon.mediahaven.com/metadata/22.1/mh/" version="22.1">
+  <mhs:Administrative>
+    <mh:ExternalId>testpid</mh:ExternalId>
+  </mhs:Administrative>
+  <mhs:Dynamic>
+    <PID>testpid</PID>
+    <CP_id>OR-5h7bt1n</CP_id>
+    <sp_name>sipin</sp_name>
+  </mhs:Dynamic>
+</mhs:Sidecar>


### PR DESCRIPTION
A MediaHaven sidecar will always contain a Dynamic tag including a PID.

There was some edge case in which the dynamic tag was not yet created when adding the PID. As a fix, explicitly create the dynamic tag upfront.