### PR TITLE
DEV-2409 allow localids on representation level

### DIFF
--- a/app/helpers/graph.py
+++ b/app/helpers/graph.py
@@ -111,40 +111,12 @@ def get_sip_info(graph: rdflib.Graph) -> SIP:
         if sip_type.startswith(graph.namespace_manager.compute_qname(sip_node)[1]):
             sip_profile = graph.namespace_manager.compute_qname(sip_type)[2]
 
+    # sip_ies = get_intellectual_entities(graph)
     sip_representations = get_representations(graph)
 
-    sip = SIP(sip_id, sip_profile, sip_representations)
+    sip = SIP(sip_id, sip_profile, [], sip_representations)
 
     return sip
-
-
-def get_local_ids_from_graph(graph: rdflib.Graph) -> dict[str, str]:
-    """Retrieves the localids from a given graph.
-
-    Args:
-        graph (rdflib.Graph): The metadata graph of the SIP.
-
-    Returns:
-        dict[str, str]: A dict where the key is the type of localid, and the value the localid
-    """
-    localids = {}
-    for identifier_object in graph.objects(
-        predicate=rdflib.URIRef("http://www.loc.gov/premis/rdf/v3/identifier")
-    ):
-        type = graph.namespace_manager.compute_qname(
-            graph.value(
-                predicate=rdflib.URIRef(
-                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-                ),
-                subject=identifier_object,
-            )
-        )[2]
-        value = graph.value(
-            predicate=rdflib.URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#value"),
-            subject=identifier_object,
-        )
-        localids[type] = str(value)
-    return localids
 
 
 def get_pid_from_graph(graph: rdflib.Graph) -> str:

--- a/app/helpers/mappers.py
+++ b/app/helpers/mappers.py
@@ -1,0 +1,62 @@
+import rdflib
+
+
+def local_id_mapper(graph, objects):
+    mapping = {}
+    local_ids = {}
+    for object in objects:
+        type = graph.namespace_manager.compute_qname(
+            graph.value(
+                predicate=rdflib.URIRef(
+                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+                ),
+                subject=object,
+            )
+        )[2]
+        value = graph.value(
+            predicate=rdflib.URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#value"),
+            subject=object,
+        )
+        local_ids[type] = str(value)
+
+    main_local_id = local_ids.pop("MEEMOO-LOCAL-ID", "")
+
+    if not main_local_id and len(list(local_ids)) == 1:
+        main_local_id = local_ids[list(local_ids)[0]]
+
+    if main_local_id:
+        mapping["mhs:Dynamic.dc_identifier_localid"] = main_local_id
+
+    if local_ids:
+        for id_type, id in local_ids.items():
+            mapping[f"mhs:Dynamic.dc_identifier_localids.{id_type}"] = [
+                *mapping.get(f"mhs:Dynamic.dc_identifier_localids.{id_type}", []),
+                id,
+            ]
+
+    return mapping
+
+
+def creator_mapper(graph, creators):
+    mapping = {}
+
+    for creator in creators:
+        x = str(creator)
+        creator_role = graph.value(
+            subject=creator, predicate=rdflib.URIRef("https://schema.org/roleName")
+        )
+        if creator_role is None:
+            creator_role = "mhs:Dynamic.dc_creators.Maker[]"
+        creator_details = graph.value(
+            subject=creator, predicate=rdflib.URIRef("https://schema.org/creator")
+        )
+        creator_name = graph.value(
+            subject=creator_details, predicate=rdflib.URIRef("https://schema.org/name")
+        )
+
+        role = f"mhs:Dynamic.dc_creators.{str(creator_role)}[]"
+        name = str(creator_name)
+
+        mapping[role] = [*mapping.get(role, []), name]
+
+    return mapping

--- a/app/helpers/transformers.py
+++ b/app/helpers/transformers.py
@@ -1,7 +1,7 @@
 import rdflib
 
 
-def dimension_transform(graph, graph_result) -> str:
+def dimension_transform(graph_result) -> str:
     unit = ""
     value = 0
     for obj in graph_result:
@@ -22,16 +22,3 @@ def dimension_transform(graph, graph_result) -> str:
 
 def language_code_transform(bcp47_code) -> str:
     return bcp47_code[0:2]
-
-
-def creator_transform(graph, graph_result) -> str:
-    for obj in graph_result:
-        if obj[0].toPython() == "https://schema.org/creator":
-            creator_name = graph.value(
-                subject=obj[1], predicate=rdflib.URIRef("https://schema.org/name")
-            ).toPython()
-        if obj[0].toPython() == "https://schema.org/roleName":
-            creator_target = f"mhs:Dynamic.dc_creators.{obj[1].toPython()}[]"
-        else:
-            creator_target = "mhs:Dynamic.dc_creators.Maker[]"
-    return (creator_target, creator_name)

--- a/app/models/intellectual_entity.py
+++ b/app/models/intellectual_entity.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass, field
+from rdflib.term import Node
+from app.models.representation import Representation
+
+
+@dataclass
+class IntellectualEntity:
+    """Class representing an intellectual entity."""
+
+    id: str
+    label: str
+    node: Node
+    representations: list[Representation] = field(default_factory=list[Representation])

--- a/app/models/sip.py
+++ b/app/models/sip.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-
+from app.models.intellectual_entity import IntellectualEntity
 from app.models.representation import Representation
 
 
@@ -9,4 +9,5 @@ class SIP:
 
     id: str
     profile: str
+    intellectual_entities: list[IntellectualEntity] = field(default_factory=list[IntellectualEntity])
     representations: list[Representation] = field(default_factory=list[Representation])

--- a/tests/helpers/test_graph.py
+++ b/tests/helpers/test_graph.py
@@ -4,7 +4,6 @@ from app.helpers.graph import (
     get_cp_id_from_graph,
     get_representations,
     parse_graph,
-    get_local_ids_from_graph,
     GraphException,
     get_sip_info,
     get_pid_from_graph,
@@ -82,14 +81,6 @@ def test_get_pid_from_graph(json_ld_graph):
     pid = get_pid_from_graph(graph)
 
     assert pid == ""
-
-
-def test_get_local_ids_from_graph(json_ld_graph):
-    excepted = {"Object_number": "v_2021073114124363", "local_id": "ce980d9"}
-    graph = parse_graph(json_ld_graph, "json-ld")
-
-    local_ids = get_local_ids_from_graph(graph)
-    assert local_ids == excepted
 
 
 def test_get_representations(json_ld_graph):

--- a/tests/resources/sidecar.xml
+++ b/tests/resources/sidecar.xml
@@ -50,12 +50,12 @@
       <Trefwoord>Trefwoord 2</Trefwoord>
       <Trefwoord>Trefwoord 3</Trefwoord>
     </dc_subjects>
-    <PID>testpid</PID>
-    <CP_id>OR-5h7bt1n</CP_id>
     <dc_identifier_localids>
       <Object_number>v_2021073114124363</Object_number>
       <local_id>ce980d9</local_id>
     </dc_identifier_localids>
+    <PID>testpid</PID>
+    <CP_id>OR-5h7bt1n</CP_id>
     <md5>18513a8d61c6f2cbaaeeedd754b01d6b</md5>
     <sp_name>sipin</sp_name>
   </mhs:Dynamic>

--- a/tests/resources/sidecar_fit.xml
+++ b/tests/resources/sidecar_fit.xml
@@ -44,8 +44,6 @@
       <Regisseur>Test regisseur naam</Regisseur>
       <Fotograaf>Cedric Verhelst</Fotograaf>
     </dc_creators>
-    <PID>testpid</PID>
-    <CP_id>OR-5h7bt1n</CP_id>
     <dc_identifier_localids>
       <Acquisition_number>acquisitie3333</Acquisition_number>
       <Alternative_number>alt444</Alternative_number>
@@ -65,6 +63,8 @@
       <WorkPID>pid16</WorkPID>
       <MEEMOO-PID>7m03z1634f</MEEMOO-PID>
     </dc_identifier_localids>
+    <PID>testpid</PID>
+    <CP_id>OR-5h7bt1n</CP_id>
     <sp_name>sipin</sp_name>
   </mhs:Dynamic>
 </mhs:Sidecar>


### PR DESCRIPTION
Previously there were only localids on the intellectual entity.
The method to build the mediahaven sidecar has been heavily refactored to allow for this change.